### PR TITLE
Add delete flag

### DIFF
--- a/include/b_tree/component/metadata.hpp
+++ b/include/b_tree/component/metadata.hpp
@@ -37,11 +37,10 @@ struct Metadata {
    *
    */
   constexpr Metadata(  //
-      const size_t is_deleted,
       const size_t offset,
       const size_t key_length,
       const size_t total_length)
-      : is_deleted{static_cast<uint32_t>(is_deleted)},
+      : is_deleted{0},
         offset{static_cast<uint32_t>(offset)},
         key_length{static_cast<uint16_t>(key_length)},
         total_length{static_cast<uint16_t>(total_length)}

--- a/include/b_tree/component/node.hpp
+++ b/include/b_tree/component/node.hpp
@@ -71,11 +71,11 @@ class Node
     const auto l_rec_len = l_key_len + kPayLen;
     auto offset = SetPayload(kPageSize, l_node);
     offset = CopyKeyFrom(l_node, l_high_meta, offset);
-    meta_array_[0] = Metadata{0, offset, l_key_len, l_rec_len};
+    meta_array_[0] = Metadata{offset, l_key_len, l_rec_len};
 
     // insert r_node
     offset = SetPayload(offset, r_node);
-    meta_array_[1] = Metadata{0, offset, 0, kPayLen};
+    meta_array_[1] = Metadata{offset, 0, kPayLen};
 
     block_size_ += l_rec_len + kPayLen;
   }
@@ -506,7 +506,7 @@ class Node
       block_size_ += total_length;
 
       memmove(&(meta_array_[pos + 1]), &(meta_array_[pos]), kMetaLen * (record_count_ - pos));
-      meta_array_[pos] = Metadata{0, offset, key_length, total_length};
+      meta_array_[pos] = Metadata{offset, key_length, total_length};
       record_count_ += 1;
     } else {
       // update
@@ -575,7 +575,7 @@ class Node
 
     // insert metadata
     memmove(&(meta_array_[pos + 1]), &(meta_array_[pos]), kMetaLen * (record_count_ - pos));
-    meta_array_[pos] = Metadata{0, offset, key_length, total_length};
+    meta_array_[pos] = Metadata{offset, key_length, total_length};
     record_count_ += 1;
 
     return kCompleted;
@@ -685,7 +685,7 @@ class Node
 
     // add metadata for a left child
     memmove(&(meta_array_[pos + 1]), &(meta_array_[pos]), sizeof(Metadata) * (record_count_ - pos));
-    meta_array_[pos] = Metadata{0, offset, key_len, rec_len};
+    meta_array_[pos] = Metadata{offset, key_len, rec_len};
 
     // update this header
     block_size_ += rec_len;
@@ -784,7 +784,7 @@ class Node
       }
     }
     const auto sep_key_len = meta_array_[pos - 1].key_length;
-    temp_node_->high_meta_ = Metadata{0, offset, sep_key_len, sep_key_len};
+    temp_node_->high_meta_ = Metadata{offset, sep_key_len, sep_key_len};
 
     // copy right half records to a right node
     auto r_offset = r_node->CopyHighKeyFrom(this, high_meta_);
@@ -1093,7 +1093,7 @@ class Node
   Node *next_{nullptr};
 
   /// the metadata of a highest key.
-  Metadata high_meta_{0, kPageSize, 0, 0};
+  Metadata high_meta_{kPageSize, 0, 0};
 
   /// an actual data block (it starts with record metadata).
   Metadata meta_array_[0];

--- a/test/metadata_test.cpp
+++ b/test/metadata_test.cpp
@@ -39,7 +39,7 @@ class MetadataFixture : public testing::Test
   void
   SetUp() override
   {
-    meta_ = Metadata{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+    meta_ = Metadata{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
   }
 
   void
@@ -96,15 +96,15 @@ TEST_F(MetadataFixture, SetTotalLengthDefaultMetadataGetUpdatedTotalLength)
 
 TEST_F(MetadataFixture, EQWithSameMetadatasReturnTrue)
 {
-  const Metadata meta_a{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
-  const Metadata meta_b{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+  const Metadata meta_a{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+  const Metadata meta_b{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
 
   EXPECT_TRUE(meta_a == meta_b);
 }
 
 TEST_F(MetadataFixture, EQWithDifferentMetadatasReturnFalse)
 {
-  const Metadata meta_a{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+  const Metadata meta_a{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
   const Metadata meta_b{};
 
   EXPECT_FALSE(meta_a == meta_b);
@@ -112,15 +112,15 @@ TEST_F(MetadataFixture, EQWithDifferentMetadatasReturnFalse)
 
 TEST_F(MetadataFixture, NEQWithSameMetadatasReturnFalse)
 {
-  const Metadata meta_a{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
-  const Metadata meta_b{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+  const Metadata meta_a{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+  const Metadata meta_b{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
 
   EXPECT_FALSE(meta_a != meta_b);
 }
 
 TEST_F(MetadataFixture, NEQWithDifferentMetadatasReturnTrue)
 {
-  const Metadata meta_a{0, kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
+  const Metadata meta_a{kExpectedOffset, kExpectedKeyLength, kExpectedTotalLength};
   const Metadata meta_b{};
 
   EXPECT_TRUE(meta_a != meta_b);


### PR DESCRIPTION
resolved #19 

葉ノードのみdelete flagを使用し，中間ノードはこれまで通りMetadataを削除する

変更点
- Metadataにdelete_flagを追加
- NodeRCにkKeyAlreadyDeletedを追加
- delete_size_にmetadataのサイズを追加
- CopyRecordFrom内でrecord_count_を更新