### PR TITLE
Refactor

### DIFF
--- a/include/b_tree/component/oml/node_varlen.hpp
+++ b/include/b_tree/component/oml/node_varlen.hpp
@@ -1235,7 +1235,7 @@ class NodeVarLen
       -> NodeRC
   {
     // check whether the node has space for a new record
-    const auto total_size = kMetaLen * record_count_ + block_size_ + new_rec_len;
+    const auto total_size = kMetaLen * (record_count_ + 1) + block_size_ + new_rec_len;
     if (total_size <= kPageSize - kHeaderLen) {
       if (mutex_.HasSameVersion(ver)) return kCompleted;
       return kNeedRetry;

--- a/include/b_tree/component/osl/b_tree.hpp
+++ b/include/b_tree/component/osl/b_tree.hpp
@@ -40,9 +40,9 @@ namespace dbgroup::index::b_tree::component::osl
  * @tparam Key a class of stored keys.
  * @tparam Payload a class of stored payloads (only fixed-length data for simplicity).
  * @tparam Comp a class for ordering keys.
- * @tparam kIsVarLen a flag for indicating variable-length keys.
+ * @tparam kUseVarLenLayout a flag for indicating variable-length keys.
  */
-template <class Key, class Payload, class Comp, bool kIsVarLen>
+template <class Key, class Payload, class Comp, bool kUseVarLenLayout>
 class BTree
 {
  public:
@@ -54,8 +54,8 @@ class BTree
   using V = Payload;
   using NodeVarLen_t = NodeVarLen<Key, Comp>;
   using NodeFixLen_t = NodeFixLen<Key, Comp>;
-  using Node_t = std::conditional_t<kIsVarLen, NodeVarLen_t, NodeFixLen_t>;
-  using BTree_t = BTree<Key, Payload, Comp, kIsVarLen>;
+  using Node_t = std::conditional_t<kUseVarLenLayout, NodeVarLen_t, NodeFixLen_t>;
+  using BTree_t = BTree<Key, Payload, Comp, kUseVarLenLayout>;
   using RecordIterator_t = RecordIterator<BTree_t>;
   using ScanKey = std::optional<std::tuple<const Key &, size_t, bool>>;
   using GC_t = ::dbgroup::memory::EpochBasedGC<Node_t>;
@@ -82,7 +82,7 @@ class BTree
       : gc_{gc_interval_micro, gc_thread_num, true}
   {
     auto *root = new (GetNodePage()) Node_t{kLeafFlag};
-    if constexpr (!kIsVarLen) {
+    if constexpr (!kUseVarLenLayout) {
       root->SetPayloadLength(kPayLen);
     }
     root_.store(root, std::memory_order_release);
@@ -403,22 +403,25 @@ class BTree
   static constexpr size_t kHeaderLen = sizeof(Node_t);
 
   /// the maximum length of keys.
-  static constexpr size_t kMaxKeyLen = (kIsVarLen) ? kMaxVarLenDataSize : sizeof(Key);
+  static constexpr size_t kMaxKeyLen = (IsVarLenData<Key>()) ? kMaxVarLenDataSize : sizeof(Key);
 
   /// the maximum length of payloads (including child pointers).
   static constexpr size_t kMaxPayLen = (kPayLen < kPtrLen) ? kPtrLen : kPayLen;
 
   /// the maximum length of records.
-  static constexpr size_t kMaxRecLen = kMaxKeyLen + kMaxPayLen + ((kIsVarLen) ? kMetaLen : 0);
+  static constexpr size_t kMaxRecLen =
+      kMaxKeyLen + kMaxPayLen + ((kUseVarLenLayout) ? kMetaLen : 0);
 
   /// the minimum block size in a certain node.
   static constexpr size_t kMinBlockSize = kPageSize - kHeaderLen - kMaxKeyLen;
 
   /// the expected length of leaf records.
-  static constexpr size_t kExpLeafRecLen = sizeof(Key) + kPayLen + ((kIsVarLen) ? kMetaLen : 0);
+  static constexpr size_t kExpLeafRecLen =
+      sizeof(Key) + kPayLen + ((kUseVarLenLayout) ? kMetaLen : 0);
 
   /// the expected length of internal records.
-  static constexpr size_t kExpInnerRecLen = sizeof(Key) + kPtrLen + ((kIsVarLen) ? kMetaLen : 0);
+  static constexpr size_t kExpInnerRecLen =
+      sizeof(Key) + kPtrLen + ((kUseVarLenLayout) ? kMetaLen : 0);
 
   /// the expected capacity of leaf nodes for bulkloading.
   static constexpr size_t kLeafNodeCap = (kMinBlockSize - kMinFreeSpaceSize) / kExpLeafRecLen;

--- a/include/b_tree/component/psl/b_tree.hpp
+++ b/include/b_tree/component/psl/b_tree.hpp
@@ -40,9 +40,9 @@ namespace dbgroup::index::b_tree::component::psl
  * @tparam Key a class of stored keys.
  * @tparam Payload a class of stored payloads (only fixed-length data for simplicity).
  * @tparam Comp a class for ordering keys.
- * @tparam kIsVarLen a flag for indicating variable-length keys.
+ * @tparam kUseVarLenLayout a flag for indicating variable-length keys.
  */
-template <class Key, class Payload, class Comp, bool kIsVarLen>
+template <class Key, class Payload, class Comp, bool kUseVarLenLayout>
 class BTree
 {
  public:
@@ -54,8 +54,8 @@ class BTree
   using V = Payload;
   using NodeVarLen_t = NodeVarLen<Key, Comp>;
   using NodeFixLen_t = NodeFixLen<Key, Comp>;
-  using Node_t = std::conditional_t<kIsVarLen, NodeVarLen_t, NodeFixLen_t>;
-  using BTree_t = BTree<Key, Payload, Comp, kIsVarLen>;
+  using Node_t = std::conditional_t<kUseVarLenLayout, NodeVarLen_t, NodeFixLen_t>;
+  using BTree_t = BTree<Key, Payload, Comp, kUseVarLenLayout>;
   using RecordIterator_t = RecordIterator<BTree_t>;
   using ScanKey = std::optional<std::tuple<const Key &, size_t, bool>>;
   using GC_t = ::dbgroup::memory::EpochBasedGC<Node_t>;
@@ -82,7 +82,7 @@ class BTree
       : gc_{gc_interval_micro, gc_thread_num, true}
   {
     auto *root = new (GetNodePage()) Node_t{kLeafFlag};
-    if constexpr (!kIsVarLen) {
+    if constexpr (!kUseVarLenLayout) {
       root->SetPayloadLength(kPayLen);
     }
     root_.store(root, std::memory_order_release);
@@ -401,22 +401,25 @@ class BTree
   static constexpr size_t kHeaderLen = sizeof(Node_t);
 
   /// the maximum length of keys.
-  static constexpr size_t kMaxKeyLen = (kIsVarLen) ? kMaxVarLenDataSize : sizeof(Key);
+  static constexpr size_t kMaxKeyLen = (IsVarLenData<Key>()) ? kMaxVarLenDataSize : sizeof(Key);
 
   /// the maximum length of payloads (including child pointers).
   static constexpr size_t kMaxPayLen = (kPayLen < kPtrLen) ? kPtrLen : kPayLen;
 
   /// the maximum length of records.
-  static constexpr size_t kMaxRecLen = kMaxKeyLen + kMaxPayLen + ((kIsVarLen) ? kMetaLen : 0);
+  static constexpr size_t kMaxRecLen =
+      kMaxKeyLen + kMaxPayLen + ((kUseVarLenLayout) ? kMetaLen : 0);
 
   /// the minimum block size in a certain node.
   static constexpr size_t kMinBlockSize = kPageSize - kHeaderLen - kMaxKeyLen;
 
   /// the expected length of leaf records.
-  static constexpr size_t kExpLeafRecLen = sizeof(Key) + kPayLen + ((kIsVarLen) ? kMetaLen : 0);
+  static constexpr size_t kExpLeafRecLen =
+      sizeof(Key) + kPayLen + ((kUseVarLenLayout) ? kMetaLen : 0);
 
   /// the expected length of internal records.
-  static constexpr size_t kExpInnerRecLen = sizeof(Key) + kPtrLen + ((kIsVarLen) ? kMetaLen : 0);
+  static constexpr size_t kExpInnerRecLen =
+      sizeof(Key) + kPtrLen + ((kUseVarLenLayout) ? kMetaLen : 0);
 
   /// the expected capacity of leaf nodes for bulkloading.
   static constexpr size_t kLeafNodeCap = (kMinBlockSize - kMinFreeSpaceSize) / kExpLeafRecLen;


### PR DESCRIPTION
ref #49 

OMLの`NeedSplit`の引数の`new_rec_len`は`Metadata`を含まないレコードサイズを想定するよう変更